### PR TITLE
refactor graphapi

### DIFF
--- a/src/library/HealthChecks/Base/RestApiHealthCheckBase.cs
+++ b/src/library/HealthChecks/Base/RestApiHealthCheckBase.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Identity.Client;
 using Microsoft.Identity.Web;
 
 namespace CloudFit.Azure.HealthChecks.Base;
@@ -6,22 +8,88 @@ public abstract class RestApiHealthCheckBase
 {
     public static ITokenAcquisition? TokenAcquisition { get; set; }
 
+    internal protected IConfidentialClientApplication? ConfidentialClientApplication { get; set; }
+
     internal protected IDictionary<string, string> Props { get; set; }
 
     internal protected string RestBaseUri { get; set; }
 
+    // internal strings representing keys in the Props dictionary.
+    internal protected static string _clientIdKey = "ClientId";
+    internal protected static string _clientSecretKey = "ClientSecret";
+    internal protected static string _tenantIdKey = "TenantId";
     internal protected static string _tokenScopeKey = "TokenScope";
+    internal protected static string _useClientTokenKey = "UseClientToken";
+    internal protected static string _defaultTokenScope = ".default";
 
     internal RestApiHealthCheckBase()
     {
         this.Props = new Dictionary<string, string>()
         {
-            { _tokenScopeKey, ".default" }
+            { _tokenScopeKey, _defaultTokenScope }
         };
+    }
+
+    // Using reflection to add the value of a property to the ConfidentialClientApplicationOptions object
+    internal void AddPropToOptions(ConfidentialClientApplicationOptions options, string propName)
+    {
+        if (!string.IsNullOrEmpty(propName) && this.Props.ContainsKey(propName))
+        {
+            var prop = typeof(ConfidentialClientApplicationOptions).GetProperty(propName);
+            if (prop != null) { prop.SetValue(options, this.Props[propName]); }
+        }
+    }
+
+    // Create an instance of a IConfidentialClientApplication
+    internal void CreateClientAuthProviderFromProps()
+    {
+        var ccAppOptions = new ConfidentialClientApplicationOptions();
+
+        AddPropToOptions(ccAppOptions, _clientIdKey);
+        AddPropToOptions(ccAppOptions, _clientSecretKey);
+        AddPropToOptions(ccAppOptions, _tenantIdKey);
+
+        this.ConfidentialClientApplication = ConfidentialClientApplicationBuilder.CreateWithApplicationOptions(ccAppOptions).Build();
+    }
+
+    // Get a token for use in authentication of rest api calls
+    internal async Task<string> GetTokenAsync(string scope)
+    {
+        var token = string.Empty;
+
+        if(UseClientToken && (this.ConfidentialClientApplication != null))
+        {
+            token = (await this.ConfidentialClientApplication.AcquireTokenForClient(new [] { scope }).ExecuteAsync()).AccessToken;
+        }
+        else if (TokenAcquisition != null)
+        {
+            token = await TokenAcquisition.GetAccessTokenForAppAsync(scope, authenticationScheme: JwtBearerDefaults.AuthenticationScheme);
+        }
+
+        return token;
+    }
+
+    // Determine whether to use a client application token
+    internal bool UseClientToken
+    {
+        get
+        {
+            var useClientToken = false;
+
+            if ((this.Props.ContainsKey(_useClientTokenKey)) &&
+                (!string.IsNullOrEmpty(this.Props[_useClientTokenKey])) &&
+                (bool.Parse(this.Props[_useClientTokenKey])))
+            {
+                useClientToken = true;
+            }
+
+            return useClientToken;
+        }
     }
 
     public virtual void SetHealthCheckProperties(IDictionary<string, object>? props)
     {
+        // Update dictionary of properties based on input argument
         if (props != null)
         {
             foreach (var key in props.Keys)
@@ -31,6 +99,12 @@ public abstract class RestApiHealthCheckBase
                     this.Props[key] = ((string)props[key]);
                 }
             }
+        }
+
+        // Try and build a client auth provider from the Props dictionary
+        if (this.UseClientToken)
+        {
+            this.CreateClientAuthProviderFromProps();
         }
     }
 }

--- a/src/library/HealthChecks/DataFactoryHealthCheck.cs
+++ b/src/library/HealthChecks/DataFactoryHealthCheck.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using CloudFit.Azure.HealthChecks.Base;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -31,7 +30,7 @@ public class DataFactoryHealthCheck : RestApiHealthCheckBase, IHealthCheck, ICon
         {
             try
             {
-                var token = await TokenAcquisition.GetAccessTokenForAppAsync($"{this.RestBaseUri}{this.Props[_tokenScopeKey]}", authenticationScheme: JwtBearerDefaults.AuthenticationScheme);
+                var token = await this.GetTokenAsync($"{this.RestBaseUri}{this.Props[_tokenScopeKey]}");
 
                 if (!string.IsNullOrEmpty(token))
                 {

--- a/src/library/HealthChecks/GraphApiHealthCheck.cs
+++ b/src/library/HealthChecks/GraphApiHealthCheck.cs
@@ -5,116 +5,44 @@ using Azure.Core;
 using Azure.Identity;
 using CloudFit.Azure.HealthChecks.Base;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Identity.Client;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 
 namespace CloudFit.Azure.HealthChecks;
 
 public class GraphApiHealthCheck : RestApiHealthCheckBase, IHealthCheck, IConfigureHealthCheck
 {
-    private static string _clientIdKey = "";
-    private static string _clientSecretKey = "";
-    private static string _tenantIdKey = "";
-    private static string _graphScopeKey = "";
-    
-    private readonly IEnumerable<string> PropNames = (new[] { "RestBaseUri", "ClientId", "ClientSecret", "TenantId", "GraphScope" });
+    private static string _graphScopeKey = "GraphScope";
 
-    // values supplied from configuration
-    private string RestBaseUri { get; set; }
-    private string ClientId { get; set; }
-    private string ClientSecret { get; set; }
-    private string TenantId { get; set; }
-    private string GraphScope { get; set; }
-
-    // holding variables for successful token
-    private string Token { get; set; }
-    private DateTime TokenExpiration { get; set; }
-
-    // default graph scope
-    private string _defaultGraphScope = ".default";
 
     // set some expected default values
     public GraphApiHealthCheck()
     {
-        this.RestBaseUri = "https://graph.microsoft.com";
-        this.GraphScope = this._defaultGraphScope;
-        this.Token = string.Empty;
-        this.TokenExpiration = DateTime.Now.AddSeconds(-10);
+        this.RestBaseUri = "https://graph.microsoft.com/";
+
+        this.Props.Add(_clientIdKey, string.Empty);
+        this.Props.Add(_clientSecretKey, string.Empty);
+        this.Props.Add(_tenantIdKey, string.Empty);
+        this.Props.Add(_graphScopeKey, _defaultTokenScope);
+        this.Props.Add(_useClientTokenKey, "true");
     }
 
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
         try
         {
-            if ((this.TokenExpiration < DateTime.Now) || string.IsNullOrEmpty(this.Token))
+            var token = await this.GetTokenAsync($"{this.RestBaseUri}{this.Props[_graphScopeKey]}");
+
+            if(string.IsNullOrEmpty(token))
             {
-                var dataDict = new Dictionary<string, string>()
-                {
-                    { "client_id", this.ClientId },
-                    { "client_secret", this.ClientSecret },
-                    { "scope", $"{this.RestBaseUri}/{this.GraphScope}" },
-                    { "grant_type", "client_credentials" }
-                };
-
-                using (var client = new HttpClient())
-                {
-                    client.Timeout = new TimeSpan(0, 0, 5);
-
-                    var content = new FormUrlEncodedContent(dataDict);
-
-                    var response_message = await client.PostAsync($"https://login.microsoftonline.com/{this.TenantId}/oauth2/v2.0/token", content);
-                    var response_content = await response_message.Content.ReadAsStringAsync();
-                    if (response_message.IsSuccessStatusCode)
-                    {
-                        var response = JsonSerializer.Deserialize<System.Text.Json.Nodes.JsonNode>(response_content);
-                        if (response != null)
-                        {
-                            //token = response.access_token;
-                            this.Token = response["access_token"].GetValue<string>();
-                            this.TokenExpiration = DateTime.Now.AddSeconds((response["expires_in"].GetValue<int>()));
-                        }
-                    }
-                    else
-                    {
-                        return HealthCheckResult.Unhealthy($"Failed to get token for graph api ({response_content}).\n tenant: {this.TenantId}\n client: {this.ClientId}\n scope: {this.GraphScope}");
-                    }
-                }
+                return HealthCheckResult.Unhealthy($"Failed to get token for graph api.\n tenant: {this.Props[_tenantIdKey]}\n client: {this.Props[_clientIdKey]}\n scope: {this.Props[_graphScopeKey]}");
             }
         }
         catch (Exception e)
         {
-            return HealthCheckResult.Unhealthy($"Error in getting graph api token.\n tenant: {this.TenantId}\n client: {this.ClientId}\n scope: {this.GraphScope}\n (error: {e.Message})", e);
+            return HealthCheckResult.Unhealthy($"Error in getting graph api token.\n tenant: {this.Props[_tenantIdKey]}\n client: {this.Props[_clientIdKey]}\n scope: {this.Props[_graphScopeKey]}\n (error: {e.Message})", e);
         }
 
-        return HealthCheckResult.Healthy($"Successfully obtained a token for: \n tenant: {this.TenantId}\n client: {this.ClientId}\n scope: {this.GraphScope}");
-    }
-
-    public void SetHealthCheckProperties(IDictionary<string, object>? props)
-    {
-        if (props != null)
-        {
-            foreach (var name in this.PropNames)
-            {
-                if (props.ContainsKey(name) && (props[name] != null))
-                {
-                    switch (name)
-                    {
-                        case "ClientId":
-                            {
-                                this.ClientId = (string)(props[name]);
-                                break;
-                            }
-                        case "ClientSecret":
-                            {
-                                this.ClientSecret = (string)(props[name]);
-                                break;
-                            }
-                        case "TenantId":
-                            {
-                                this.TenantId = (string)(props[name]);
-                                break;
-                            }
-                    }
-                }
-            }
-        }
+        return HealthCheckResult.Healthy("Successfully obtained a token for Graph API.");
     }
 }

--- a/src/library/HealthChecks/GraphApiHealthCheck.cs
+++ b/src/library/HealthChecks/GraphApiHealthCheck.cs
@@ -10,6 +10,11 @@ namespace CloudFit.Azure.HealthChecks;
 
 public class GraphApiHealthCheck : RestApiHealthCheckBase, IHealthCheck, IConfigureHealthCheck
 {
+    private static string _clientIdKey = "";
+    private static string _clientSecretKey = "";
+    private static string _tenantIdKey = "";
+    private static string _graphScopeKey = "";
+    
     private readonly IEnumerable<string> PropNames = (new[] { "RestBaseUri", "ClientId", "ClientSecret", "TenantId", "GraphScope" });
 
     // values supplied from configuration

--- a/src/library/HealthChecks/GraphApiHealthCheck.cs
+++ b/src/library/HealthChecks/GraphApiHealthCheck.cs
@@ -1,12 +1,5 @@
-using System.Net.Http.Headers;
-using System.Text;
-using System.Text.Json;
-using Azure.Core;
-using Azure.Identity;
 using CloudFit.Azure.HealthChecks.Base;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Identity.Client;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 
 namespace CloudFit.Azure.HealthChecks;
 


### PR DESCRIPTION
moved all token logic into base class.

support dependency injected server ITokenAcquisition or IConfidentialClientApplication for being able to acquire a token for authentication with rest endpoints.

