### PR TITLE
refactor to use a different default token provider.

### DIFF
--- a/src/library/DI/InjectHealthChecksExtension.cs
+++ b/src/library/DI/InjectHealthChecksExtension.cs
@@ -1,8 +1,6 @@
-using CloudFit.Azure.HealthChecks.Base;
 using CloudFit.Azure.HealthChecks.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Identity.Web;
 
 namespace CloudFit.Azure.HealthChecks.DI;
 
@@ -21,8 +19,6 @@ public static class InjectHealthChecksExtensions
         var sp = services.BuildServiceProvider();
 
         sp.ProcessIConfiguration(services, healthCheckBuilder);
-
-        sp.ProcessITokenAcquisition();
 
     }
 
@@ -84,16 +80,6 @@ public static class InjectHealthChecksExtensions
 
                 builder.AddDbContextHealthChecks(services, healthCheckSettings);
             }
-        }
-    }
-
-    private static void ProcessITokenAcquisition(this ServiceProvider serviceProvider)
-    {
-        var tokenAcquisition = serviceProvider.GetService<ITokenAcquisition>();
-
-        if (tokenAcquisition != null)
-        {
-            RestApiHealthCheckBase.TokenAcquisition = tokenAcquisition;
         }
     }
 }

--- a/src/library/HealthChecks/StorageHealthCheck.cs
+++ b/src/library/HealthChecks/StorageHealthCheck.cs
@@ -42,7 +42,7 @@ public class StorageHealthCheck : RestApiHealthCheckBase, IHealthCheck, IConfigu
                 {
                     using (var client = new HttpClient())
                     {
-                        client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+                        client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue(JwtBearerDefaults.AuthenticationScheme, token);
                         client.DefaultRequestHeaders.Add("x-ms-version", "2021-08-06");
                         client.DefaultRequestHeaders.Add("x-ms-date", $"{DateTime.UtcNow.ToString("ddd, dd MMM yyyy HH:mm:ss")} GMT");
 


### PR DESCRIPTION
changed the logic around which token provider was used as the default.

this appears to resolve a couple "hiccups" in getting the right token for azure storage.

also still works for other health checks impacted by the change in provider.